### PR TITLE
Breadcrumbs

### DIFF
--- a/navigation/navigation_prototypes/launch/breadcrumbs.launch
+++ b/navigation/navigation_prototypes/launch/breadcrumbs.launch
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<launch>
+
+  <node pkg="navigation_prototypes" type="breadcrumbs.py" name="breadcrumbs" output="screen" />
+  <node pkg="rviz" type="rviz" name="rviz" />
+  <node pkg="keyboard" type="keyboard" name="keyboard" />
+
+</launch>

--- a/navigation/navigation_prototypes/prototypes/breadcrumbs.py
+++ b/navigation/navigation_prototypes/prototypes/breadcrumbs.py
@@ -1,0 +1,95 @@
+import numpy as np
+import rospy
+from copy import deepcopy
+
+class Breadcrumbs():
+    def __init__(self):
+        self.path_width = 1.5
+        self.crumb_threshold = 3
+        self.backtrack = 0
+
+    def calculate_keypoints(self, crumb_list):
+        """ Takes in list of points in an x by 3 numpy
+        array. Calculates keypoints where path turns """
+
+        keypoints = crumb_list[0, :].reshape(1, 3)
+        edible_crumbs = deepcopy(crumb_list)
+
+        while len(edible_crumbs):
+            last_keypoint = keypoints[-1, :]
+            #print(last_keypoint)
+            next_keypoint_index = self.get_next_keypoint(last_keypoint,
+                                                        edible_crumbs)
+            next_keypoint = edible_crumbs[next_keypoint_index, :]
+            edible_crumbs = edible_crumbs[next_keypoint_index + 1:, :]
+            keypoints = np.vstack((keypoints, next_keypoint))
+
+        return keypoints
+
+    def get_next_keypoint(self, last_keypoint, edible_crumbs):
+        """ Calculates the index of the next keypoint in a path, given a list
+        of points and the position of the last keypoint. """
+
+        for index, crumb in enumerate(edible_crumbs):
+            current_crumbs = deepcopy(edible_crumbs)
+            current_crumbs = current_crumbs[:index + 1, :]
+
+            point_vec = crumb - last_keypoint
+            #print(point_vec)
+            point_vec = point_vec.T
+
+            #   Rotate point_vec 90 degrees to find normal vector
+            norm_vec = np.matmul(np.asarray([[0, 1, 0],
+                                            [-1, 0, 0],
+                                            [0, 0, 1]]), point_vec)
+            unit_norm_vec = norm_vec/np.linalg.norm(norm_vec)
+            #print(unit_norm_vec)
+
+            #   TODO make sure that calculating vectors in 3 dimensions
+            #   doesn't reduce accuracy
+
+            list_of_distances = np.matmul(current_crumbs - last_keypoint,
+                                        unit_norm_vec)
+            list_of_distances = np.absolute(list_of_distances)
+            list_of_distances = np.sort(list_of_distances)[::-1]
+
+            if self.has_turned(list_of_distances):
+                print("TURNED")
+                return index - self.backtrack
+        return len(edible_crumbs) - 1
+
+    def has_turned(self, list_of_distances):
+        #print(list_of_distances)
+        counter = 0
+        for i, item in enumerate(list_of_distances):
+            #print(item)
+            if counter >= self.crumb_threshold:
+                return True
+            elif item > self.path_width:
+                counter += 1
+            elif i < self.crumb_threshold:
+                return False
+        return False
+
+if __name__ == '__main__':
+    trail = np.asarray([[0, 0, 0],
+                        [0, 1, 0],
+                        [0, 2, 0],
+                        [0, 3, 0],
+                        [0, 4, 0],
+                        [0, 5, 0],
+                        [1, 5, 0],
+                        [2, 5, 0],
+                        [3, 5, 0],
+                        [4, 5, 0],
+                        [5, 5, 0],
+                        [5, 6, 0],
+                        [5, 7, 0],
+                        [5, 8, 0],
+                        [5, 9, 0],
+                        [5, 10, 0]])
+    a = Breadcrumbs()
+    a.path_width = 0.5
+    a.crumb_threshold = 1
+    a.backtrack = 1
+    print(a.calculate_keypoints(trail))

--- a/navigation/navigation_prototypes/prototypes/breadcrumbs.py
+++ b/navigation/navigation_prototypes/prototypes/breadcrumbs.py
@@ -319,9 +319,9 @@ class Breadcrumbs():
         if stairs:
             height_diff = self.keypoint_list[0, 2] - self.pose[0][2]
             slope = height_diff/self.new_dist
-            if slope >= 0.5:
+            if slope >= 0.3:
                 direction = direction + "and walk up the stairs. "
-            elif slope <= -0.5:
+            elif slope <= -0.3:
                 direction = direction + "and walk down the stairs. "
 
         #   Give information for distance to next waypoint


### PR DESCRIPTION
## Breadcrumb trails
### An assistive app to navigate back to a previous location. 
During recording mode, continuously drops "breadcrumbs," then converts trail into a series of "keypoints" where the user turned using the Ramer-Douglas-Peucher algorithm. During navigation mode, gives auditory directions to each of these keypoints in reverse order to direct the user back to their starting position.

Tested using the Tango and portable hotspot through the halls and stairways of the Academic Center.

### Files added
breadcrumbs.py
breadcrumbs.launch

### Visualization
![pathfindingbreadcrumbs](https://user-images.githubusercontent.com/22649301/28035002-000ff396-6581-11e7-8afa-e8f6525148ce.jpg)

### To run
- Use the following command: `roslaunch navigation_prototypes breadcrumbs.launch`
- Add **/key_point** and **/crm_point** publishers to the RViz display
- Go to the keyboard window
- Use the following keys to test the application:
          D: start recording mode
          S: stop recording mode
          C: start navigation mode
          X: stop navigation mode


 