### PR TITLE
Stop clew app from auto-locking and dimming

### DIFF
--- a/navigation/ios_apps/ClewApp/Clew/AppDelegate.swift
+++ b/navigation/ios_apps/ClewApp/Clew/AppDelegate.swift
@@ -21,6 +21,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window = UIWindow(frame:UIScreen.main.bounds)
         window?.makeKeyAndVisible()
         window?.rootViewController = ViewController()
+        UIApplication.shared.isIdleTimerDisabled = true
         return true
     }
 


### PR DESCRIPTION
Tested on iphone 8, running iOS 11.4